### PR TITLE
Fix bug with srcset not correctly replacing URLS

### DIFF
--- a/includes/classes/DomainManager.php
+++ b/includes/classes/DomainManager.php
@@ -3,14 +3,14 @@ namespace EAMann\Dynamic_CDN;
 
 /**
  * Companion method for DomainManager object.
- * 
+ *
  * @param string $domain
- * 
+ *
  * @return DomainManager
  */
 function DomainManager( $domain ) {
 	static $managers = array();
-	
+
 	if ( ! isset( $managers[ $domain ] ) ) {
 		$managers[ $domain ] = new DomainManager( $domain );
 	}
@@ -51,7 +51,7 @@ class DomainManager {
 
 	/**
 	 * Get the default domain manager for the current site.
-	 * 
+	 *
 	 * @return DomainManager
 	 */
 	public static function current() {
@@ -72,7 +72,7 @@ class DomainManager {
 	public static function last() {
 		return self::$last;
 	}
-	
+
 	public function __construct( $domain ) {
 		$this->site_domain = $domain;
 
@@ -83,7 +83,7 @@ class DomainManager {
 	 * Add a CDN domain to the collection.
 	 *
 	 * @param string $cdn_domain
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function add( $cdn_domain ) {
@@ -91,9 +91,8 @@ class DomainManager {
 			return false;
 		} else {
 			$this->cdn_domains[] = $cdn_domain;
-
 			$this->has_domains = true;
-			
+
 			return true;
 		}
 	}
@@ -120,36 +119,49 @@ class DomainManager {
 
 	/**
 	 * Potentially replace a given file URL with a CDN-ified version
-	 * 
+	 *
 	 * @param string $file_url
-	 * 
+	 *
 	 * @return string
 	 */
 	public function new_url( $file_url ) {
 		$domain = $this->cdn_domain( basename( $file_url ) );
 		$url = explode( '://', $this->site_domain );
-		array_shift( $url );
+
+		$proto_pattern = '^((https?):)?\/\/';
+
+		if ( count( $url ) > 1 ) array_shift($url);
+
+		// If the CDN domain has an existing protocol use that
+		preg_match("#{$proto_pattern}#", $domain, $matches);
 
 		/**
 		 * Allows plugins to override the HTTPS protocol
-		 * 
+		 *
 		 * @param string $scheme
 		 */
-		$scheme = apply_filters( 'dynamic_cdn_protocol', ( is_ssl() ? 'https' : 'http' ) );
+		$scheme = apply_filters(
+			'dynamic_cdn_protocol',
+			( count($matches) >= 2 ? $matches[2] : ( is_ssl() ? 'https' : 'http' ) )
+		);
+
+		$domain = esc_url( $scheme . '://' . preg_replace( "#{$proto_pattern}#" , '', $domain ) );
 
 		/**
 		 * Modify the domain we're rewriting, should an aliasing plugin be used (for example)
 		 *
 		 * @param string $site_domain
 		 */
-		$url = apply_filters( 'dynamic_cdn_site_domain', esc_url( $scheme . '://' . $url[0] ) );
-		
-		return str_replace( $url, $domain, $file_url );
+		$url = apply_filters( 'dynamic_cdn_site_domain', $url[0] );
+
+		$pattern = "#{$proto_pattern}" . preg_quote($url, '#') . '#';
+
+		return preg_replace( $pattern, $domain, $file_url );
 	}
 
 	/**
 	 * Verify whether or not the current manager has any registered CDN domains.
-	 * 
+	 *
 	 * @return bool
 	 */
 	public function has_domains() {

--- a/tests/phpunit/Core_Tests.php
+++ b/tests/phpunit/Core_Tests.php
@@ -58,6 +58,46 @@ class Core_Tests extends Base\TestCase {
 		$this->assertEquals( 'https://cdn1.com/image.jpg', $replacer( $source )['url'] );
 	}
 
+	public function test_srcset_replacement_no_protocol_cdn() {
+		$manager = Base\DomainManager( 'http://test1.com' );
+		$manager->add( 'cdn1.com' );
+
+		// Mocks
+		M::wpFunction( 'is_ssl', [ 'return' => false ] );
+		M::wpPassthruFunction( 'esc_url' );
+
+		$source = [
+			'url' => 'http://test1.com/image.jpg'
+		];
+
+		$replacer = srcset_replacer( 'http://test1.com' );
+
+		$this->assertEquals( 'http://cdn1.com/image.jpg', $replacer( $source )['url'] );
+	}
+
+
+	public function test_host_with_port() {
+		M::wpFunction( 'is_ssl', [ 'return' => true ] );
+
+		\WP_Mock::wpFunction( 'get_bloginfo', array(
+			'args' => 'url',
+			'return' => 'http://localhost:9001'
+		) );
+		\WP_Mock::wpFunction( 'wp_upload_dir', array(
+			'return' => array(
+				'baseurl' => 'http://localhost:9001/wp-content/uploads'
+			)
+		) );
+		$manager = Base\DomainManager( 'localhost:9001' );
+		$manager->extensions = array( 'jpg' );
+		$manager->add( 'cdn1.com' );
+		$content = '<img src="http://localhost:9001/puppy.jpg" />';
+		$filtered_content = filter( $content );
+		$expected = '<img src="https://cdn1.com/puppy.jpg" />';
+
+		$this->assertEquals( $expected, $filtered_content );
+	}
+
 	public function test_query_string() {
 		M::wpFunction( 'is_ssl', [ 'return' => true ] );
 
@@ -87,7 +127,6 @@ class Core_Tests extends Base\TestCase {
 		';
 
 		$this->assertEquals( $expected, $filtered_content );
-
 	}
 
 	public function test_escaped_content() {
@@ -143,5 +182,4 @@ class Core_Tests extends Base\TestCase {
 		';
 		$this->assertEquals( $expected, $filtered_content );
 	}
-
 }


### PR DESCRIPTION
## Bugs
- Fixes bug with srcset not correctly working. This code is expecting this to return a URL with a protocol https://github.com/ericmann/dynamic-cdn/blob/master/includes/classes/DomainManager.php#L129. In the unit test you have `http://test.com`. But in my WP install it just gets `test.com`. So I just changed the new_url function accept either format. I also added a unit test for this behavior.

## Features
- Support a port in the site url, for instance i run off localhost:8080 locally since I am running nginx on that port.
