### PR TITLE
Add support for WP-API v2

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -74,7 +74,7 @@ function initialize_manager() {
 	$manager->extensions = apply_filters( 'dynamic_cdn_extensions', array( 'jpe?g', 'gif', 'png', 'bmp', 'js', 'ico' ) );
 
 	if ( ! is_admin() ) {
-		add_action( 'template_redirect', '\EAMann\Dynamic_CDN\Core\template_redirect' );
+		add_action( 'template_redirect', '\EAMann\Dynamic_CDN\Core\create_buffer' );
 
 		if ( $manager->uploads_only ) {
 			add_filter( 'the_content'/*'dynamic_cdn_content'*/, '\EAMann\Dynamic_CDN\Core\filter_uploads_only' );
@@ -83,6 +83,8 @@ function initialize_manager() {
 		}
 
 		add_filter( 'wp_calculate_image_srcset', '\EAMann\Dynamic_CDN\Core\srcsets', 10, 5 );
+
+		add_action( 'rest_api_init', '\EAMann\Dynamic_CDN\Core\create_buffer' );
 
 		$cdn_domains = array();
 		if ( defined( 'DYNCDN_DOMAINS' ) ) {
@@ -154,7 +156,7 @@ function srcset_replacer( $domain ) {
 /**
  * Create an output buffer so we can dynamically rewrite any URLs going out.
  */
-function template_redirect() {
+function create_buffer() {
 	ob_start( '\EAMann\Dynamic_CDN\Core\ob' );
 }
 


### PR DESCRIPTION
## Background
Due to https://github.com/WP-API/WP-API/pull/1270/ the `template_redirect` action does not run
when a WP-API v2 request is being served. So hook into `rest_api_init` so WP-API v2 responses
can be modified.

## Testing instructions
- Enable dynamic cdn plugin
- View a WP-API v2 response, i.e. `/api/v4/wp/v2/posts/`
- See that image urls are rewritten