### PR TITLE
Feature/json property support

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -215,7 +215,7 @@ function filter_uploads_only( $content ) {
 	$preg_path = str_replace( '/', '\\\?/', preg_quote( $path, '#' ) );
 
 	// Targeted replace just on uploads URLs
-	$pattern = "#=(\\\?[\"'])"  // open equal sign and opening quote
+	$pattern = "#(\\\?[\"'])"  // opening quote
 	. "(https?:\\\?/\\\?/{$domain})?"// domain (optional)
 	. "\\\?/($preg_path\\\?/" // uploads path
 	// . "((?:(?!\\1]).)+)" // look for anything that's not our opening quote
@@ -251,7 +251,7 @@ function filter( $content ) {
 	$url = apply_filters( 'dynamic_cdn_site_domain', rtrim( implode( '://', $url ), '/' ) );
 	$url = preg_quote( $url, '#' );
 
-	$pattern = "#=(\\\?[\"'])" // open equal sign and opening quote
+	$pattern = "#(\\\?[\"'])" // opening quote
 	. "(https?:\\\?/\\\?/{$url})?\\\?/"  // domain (optional)
 	// . "([^/](?:(?!\\1).)+)" // look for anything that's not our opening quote
 	. "([^/][\w\s\\\/\-\,\.]+)" // look for anything that's not our opening quote
@@ -302,7 +302,7 @@ function filter_cb( $matches ) {
 		$add_slashes = false;
 	}
 
-	$result = "={$matches[1]}{$scheme}:"
+	$result = "{$matches[1]}{$scheme}:"
 						. ( $add_slashes ? addcslashes("//{$url}/", '/') : "//{$url}/" )
 						. "{$matches[3]}.{$matches[4]}{$query_string}{$matches[1]}";
 

--- a/tests/phpunit/Core_Tests.php
+++ b/tests/phpunit/Core_Tests.php
@@ -182,4 +182,26 @@ class Core_Tests extends Base\TestCase {
 		';
 		$this->assertEquals( $expected, $filtered_content );
 	}
+
+	public function test_json_content() {
+		M::wpFunction( 'is_ssl', [ 'return' => true ] );
+		\WP_Mock::wpFunction( 'get_bloginfo', array(
+			'args' => 'url',
+			'return' => 'http://localhost'
+		) );
+		\WP_Mock::wpFunction( 'wp_upload_dir', array(
+			'return' => array(
+				'baseurl' => 'http://localhost/wp-content/uploads'
+			)
+		) );
+		$manager = Base\DomainManager( 'localhost' );
+		$manager->extensions = array( 'jpg' );
+		$manager->add( 'cdn1.com' );
+		$site_url = 'http://localhost';
+		$content = '{"file": "/wp-content/uploads/puppy.jpg"}';
+		$filtered_content = filter( $content );
+		$expected = '{"file": "https://cdn1.com/wp-content/uploads/puppy.jpg"}';
+		$this->assertEquals( $expected, $filtered_content );
+	}
+
 }


### PR DESCRIPTION
## Background
This adds support for CDNizing values like `"image": "foo.jpg"`. As discussed in https://github.com/ericmann/dynamic-cdn/issues/12, the approach is to remove the leading `=` from the regex, as this is the same approach other libraries are taking.

## Testing Instructions
There are unit tests for this feature, but you can also try pulling this into a WP install and see that API responses CDN values like `"image": "foo.jpg"`. 