### PR TITLE
Added file types to the list

### DIFF
--- a/includes/functions/core.php
+++ b/includes/functions/core.php
@@ -84,7 +84,7 @@ function initialize_manager() {
 	 *
 	 * @param array $extensions
 	 */
-	$manager->extensions = apply_filters( 'dynamic_cdn_extensions', array( 'jpe?g', 'gif', 'png', 'bmp', 'js', 'ico' ) );
+	$manager->extensions = apply_filters( 'dynamic_cdn_extensions', array( 'jpe?g', 'gif', 'png', 'bmp', 'js', 'mp4', 'mp3', 'flac', 'mid', 'midi', 'wav', 'ogg', 'ogv', 'svg', 'svgz', 'pdf', 'doc', 'docx', 'ico' ) );
 
 	if ( ! is_admin() ) {
 		add_action( 'template_redirect', '\EAMann\Dynamic_CDN\Core\create_buffer' );


### PR DESCRIPTION
We just had a situation where a lot of traffic was driven to an mp4 file that ended up served from our origin rather than our CDN.  I took a look at the file list in this plugin and added a number of file types that are safe bets to serve from a CDN.  I considered adding css files to this list, but didn't due to concerns with fonts and such loading from a different domain than the origin.  Interested in your thoughts on if adding css would be safe.  